### PR TITLE
fix engines/spf/config -- '1-!' is missed

### DIFF
--- a/engines/spf/config.fs
+++ b/engines/spf/config.fs
@@ -189,6 +189,10 @@ TRUE CONSTANT FLOATING-EXT
 
 [THEN]
 
+( Toolbelt )
+
+include ffl/tlb.fs
+
 
 ( Exceptions )
 
@@ -210,10 +214,6 @@ s" Wrong file data"    exception constant exp-wrong-file-data    ( -- n = Wrong 
 s" Wrong checksum"     exception constant exp-wrong-checksum     ( -- n = Wrong checksum )
 s" Wrong length"       exception constant exp-wrong-length       ( -- n = Wrong length )
 s" Invalid data"       exception constant exp-invalid-data       ( -- n = Invalid data exception number )
-
-( Toolbelt )
-
-include ffl/tlb.fs
 
 [ELSE]
   drop


### PR DESCRIPTION
The word '1-!' was used before it was defined (it is defined in tlb.fs).
The issue arose in the last refactoring, commit aa83dd64 "Toolbelt cont" on 2016-07-19
